### PR TITLE
fix: properly clear internal waiters on `Mutex`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,31 @@
+{
+  "version": "3",
+  "packages": {
+    "specifiers": {
+      "jsr:@std/assert@^1.0.2": "jsr:@std/assert@1.0.2",
+      "jsr:@std/async@^1.0.2": "jsr:@std/async@1.0.2",
+      "jsr:@std/internal@^1.0.1": "jsr:@std/internal@1.0.1"
+    },
+    "jsr": {
+      "@std/assert@1.0.2": {
+        "integrity": "ccacec332958126deaceb5c63ff8b4eaf9f5ed0eac9feccf124110435e59e49c",
+        "dependencies": [
+          "jsr:@std/internal@^1.0.1"
+        ]
+      },
+      "@std/async@1.0.2": {
+        "integrity": "36e7f0f922c843b45df546857d269f01ed4d0406aced2a6639eac325b2435e43"
+      },
+      "@std/internal@1.0.1": {
+        "integrity": "6f8c7544d06a11dd256c8d6ba54b11ed870aac6c5aeafff499892662c57673e6"
+      }
+    }
+  },
+  "remote": {},
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^1.0.2",
+      "jsr:@std/async@^1.0.2"
+    ]
+  }
+}


### PR DESCRIPTION
Close https://github.com/jsr-core/asyncutil/issues/27

### Before
![CleanShot 2024-08-13 at 06 08 12](https://github.com/user-attachments/assets/e8f269c8-ca6a-4d1e-b4f6-e6ef95397993)

### After
![CleanShot 2024-08-13 at 06 08 26](https://github.com/user-attachments/assets/4b6591da-6465-406f-a929-cb3c0694eb48)

