### PR TITLE
feat: Performance improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,9 @@ operation.
 import { Semaphore } from "@core/asyncutil/semaphore";
 
 const sem = new Semaphore(5);
-const worker = () => {
-  return sem.lock(async () => {
-    // do something
-  });
+const worker = async () => {
+  using _lock = await sem.acquire();
+  // do something
 };
 await Promise.all([...Array(10)].map(() => worker()));
 ```

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -25,6 +25,7 @@
       "LICENSE"
     ],
     "exclude": [
+      "**/*_bench.ts",
       "**/*_test.ts",
       ".*"
     ]

--- a/deno.lock
+++ b/deno.lock
@@ -2,12 +2,19 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "jsr:@core/asyncutil@1.0.2": "jsr:@core/asyncutil@1.0.2",
       "jsr:@core/iterutil@^0.6.0": "jsr:@core/iterutil@0.6.0",
       "jsr:@std/assert@^1.0.2": "jsr:@std/assert@1.0.2",
       "jsr:@std/async@^1.0.2": "jsr:@std/async@1.0.2",
       "jsr:@std/internal@^1.0.1": "jsr:@std/internal@1.0.1"
     },
     "jsr": {
+      "@core/asyncutil@1.0.2": {
+        "integrity": "efb2c41ccf6d9ba481f1fedb87734813530ef64ca2193a89f595cd1483b71476",
+        "dependencies": [
+          "jsr:@core/iterutil@^0.6.0"
+        ]
+      },
       "@core/iterutil@0.6.0": {
         "integrity": "8de0d0062a515496ae744983941d7e379668c2ee2edf43f63423e8da753828b1"
       },

--- a/deno.lock
+++ b/deno.lock
@@ -32,7 +32,9 @@
       }
     }
   },
-  "remote": {},
+  "remote": {
+    "https://gist.githubusercontent.com/PandaWorker/ec07a22b55668073e70237285da18cee/raw/612f7cf8f8df80a114780ddf07ca9acdebe97b9f/MyMutex.ts": "b129ed3098da1eb67c13027a7baa6a5386d8e2caea2cfd5bb4ab6a4debcb908f"
+  },
   "workspace": {
     "dependencies": [
       "jsr:@core/iterutil@^0.6.0",

--- a/mutex_bench.ts
+++ b/mutex_bench.ts
@@ -1,0 +1,7 @@
+import { Mutex } from "./mutex.ts";
+
+const mutex = new Mutex();
+
+Deno.bench("Mutex", async function () {
+  using _lock = await mutex.acquire();
+});

--- a/mutex_bench.ts
+++ b/mutex_bench.ts
@@ -1,7 +1,18 @@
 import { Mutex } from "./mutex.ts";
+import { Mutex as Mutex102 } from "jsr:@core/asyncutil@1.0.2/mutex";
+import { Mutex as MutexIssue30 } from "https://gist.githubusercontent.com/PandaWorker/ec07a22b55668073e70237285da18cee/raw/612f7cf8f8df80a114780ddf07ca9acdebe97b9f/MyMutex.ts";
 
 const mutex = new Mutex();
-
 Deno.bench("Mutex", async function () {
   using _lock = await mutex.acquire();
+});
+
+const mutex102 = new Mutex102();
+Deno.bench("Mutex (1.0.2)", async function () {
+  using _lock = await mutex102.acquire();
+});
+
+const mutexIssue30 = new MutexIssue30();
+Deno.bench("Mutex (Issue #30)", async function () {
+  using _lock = await mutexIssue30.acquire();
 });

--- a/semaphore_bench.ts
+++ b/semaphore_bench.ts
@@ -1,10 +1,20 @@
 import { Semaphore } from "./semaphore.ts";
+import { Semaphore as Semaphore102 } from "jsr:@core/asyncutil@1.0.2/semaphore";
 
 const sem = new Semaphore(5);
-
 Deno.bench("Semaphore", async function () {
   const worker = () => {
     return sem.lock(async () => {
+      // do nothing
+    });
+  };
+  await Promise.all(Array.from({ length: 100 }).map(() => worker()));
+});
+
+const sem102 = new Semaphore102(5);
+Deno.bench("Semaphore (1.0.2)", async function () {
+  const worker = () => {
+    return sem102.lock(async () => {
       // do nothing
     });
   };

--- a/semaphore_bench.ts
+++ b/semaphore_bench.ts
@@ -1,0 +1,12 @@
+import { Semaphore } from "./semaphore.ts";
+
+const sem = new Semaphore(5);
+
+Deno.bench("Semaphore", async function () {
+  const worker = () => {
+    return sem.lock(async () => {
+      // do nothing
+    });
+  };
+  await Promise.all(Array.from({ length: 100 }).map(() => worker()));
+});

--- a/semaphore_test.ts
+++ b/semaphore_test.ts
@@ -2,98 +2,192 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { Semaphore } from "./semaphore.ts";
 
 Deno.test("Semaphore", async (t) => {
-  await t.step(
-    "regulates the number of workers concurrently running (n=5)",
-    async () => {
-      let nworkers = 0;
-      const results: number[] = [];
-      const sem = new Semaphore(5);
-      const worker = () => {
-        return sem.lock(async () => {
+  await t.step("with using statement", async (t) => {
+    await t.step(
+      "regulates the number of workers concurrently running (n=5)",
+      async () => {
+        let nworkers = 0;
+        const results: number[] = [];
+        const sem = new Semaphore(5);
+        const worker = async () => {
+          using _lock = await sem.acquire();
           nworkers++;
           results.push(nworkers);
           await new Promise((resolve) => setTimeout(resolve, 10));
           nworkers--;
-        });
-      };
-      await Promise.all([...Array(10)].map(() => worker()));
-      assertEquals(nworkers, 0);
-      assertEquals(results, [
-        1,
-        2,
-        3,
-        4,
-        5,
-        5,
-        5,
-        5,
-        5,
-        5,
-      ]);
-    },
-  );
+        };
+        await Promise.all([...Array(10)].map(() => worker()));
+        assertEquals(nworkers, 0);
+        assertEquals(results, [
+          1,
+          2,
+          3,
+          4,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+        ]);
+      },
+    );
 
-  await t.step(
-    "regulates the number of workers concurrently running (n=1)",
-    async () => {
-      let nworkers = 0;
-      const results: number[] = [];
-      const sem = new Semaphore(1);
-      const worker = () => {
-        return sem.lock(async () => {
+    await t.step(
+      "regulates the number of workers concurrently running (n=1)",
+      async () => {
+        let nworkers = 0;
+        const results: number[] = [];
+        const sem = new Semaphore(1);
+        const worker = async () => {
+          using _lock = await sem.acquire();
           nworkers++;
           results.push(nworkers);
           await new Promise((resolve) => setTimeout(resolve, 10));
           nworkers--;
-        });
-      };
-      await Promise.all([...Array(10)].map(() => worker()));
-      assertEquals(nworkers, 0);
-      assertEquals(results, [
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-      ]);
-    },
-  );
+        };
+        await Promise.all([...Array(10)].map(() => worker()));
+        assertEquals(nworkers, 0);
+        assertEquals(results, [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+        ]);
+      },
+    );
 
-  await t.step(
-    "regulates the number of workers concurrently running (n=10)",
-    async () => {
-      let nworkers = 0;
-      const results: number[] = [];
-      const sem = new Semaphore(10);
-      const worker = () => {
-        return sem.lock(async () => {
+    await t.step(
+      "regulates the number of workers concurrently running (n=10)",
+      async () => {
+        let nworkers = 0;
+        const results: number[] = [];
+        const sem = new Semaphore(10);
+        const worker = async () => {
+          using _lock = await sem.acquire();
           nworkers++;
           results.push(nworkers);
           await new Promise((resolve) => setTimeout(resolve, 10));
           nworkers--;
-        });
-      };
-      await Promise.all([...Array(10)].map(() => worker()));
-      assertEquals(nworkers, 0);
-      assertEquals(results, [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-      ]);
-    },
-  );
+        };
+        await Promise.all([...Array(10)].map(() => worker()));
+        assertEquals(nworkers, 0);
+        assertEquals(results, [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+        ]);
+      },
+    );
+  });
+
+  await t.step("with lock method", async (t) => {
+    await t.step(
+      "regulates the number of workers concurrently running (n=5)",
+      async () => {
+        let nworkers = 0;
+        const results: number[] = [];
+        const sem = new Semaphore(5);
+        const worker = () => {
+          return sem.lock(async () => {
+            nworkers++;
+            results.push(nworkers);
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            nworkers--;
+          });
+        };
+        await Promise.all([...Array(10)].map(() => worker()));
+        assertEquals(nworkers, 0);
+        assertEquals(results, [
+          1,
+          2,
+          3,
+          4,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+        ]);
+      },
+    );
+
+    await t.step(
+      "regulates the number of workers concurrently running (n=1)",
+      async () => {
+        let nworkers = 0;
+        const results: number[] = [];
+        const sem = new Semaphore(1);
+        const worker = () => {
+          return sem.lock(async () => {
+            nworkers++;
+            results.push(nworkers);
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            nworkers--;
+          });
+        };
+        await Promise.all([...Array(10)].map(() => worker()));
+        assertEquals(nworkers, 0);
+        assertEquals(results, [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+        ]);
+      },
+    );
+
+    await t.step(
+      "regulates the number of workers concurrently running (n=10)",
+      async () => {
+        let nworkers = 0;
+        const results: number[] = [];
+        const sem = new Semaphore(10);
+        const worker = () => {
+          return sem.lock(async () => {
+            nworkers++;
+            results.push(nworkers);
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            nworkers--;
+          });
+        };
+        await Promise.all([...Array(10)].map(() => worker()));
+        assertEquals(nworkers, 0);
+        assertEquals(results, [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+        ]);
+      },
+    );
+  });
 
   await t.step(
     "throws RangeError if size is not a positive safe integer",


### PR DESCRIPTION
Performance improvement refactoring suggested in https://github.com/jsr-core/asyncutil/issues/30 are applied.

```
Check file:///Users/alisue/ogh/jsr-core/asyncutil/mutex_bench.ts
Check file:///Users/alisue/ogh/jsr-core/asyncutil/semaphore_bench.ts
cpu: Apple M1 Max
runtime: deno 1.45.4 (aarch64-apple-darwin)

file:///Users/alisue/ogh/jsr-core/asyncutil/mutex_bench.ts
benchmark              time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------------- -----------------------------
Mutex                 452.41 ns/iter   2,210,370.0 (439.27 ns … 545.97 ns) 446.38 ns 537.83 ns 545.97 ns
Mutex (1.0.2)         666.79 ns/iter   1,499,722.7 (636.54 ns … 947.56 ns) 653.95 ns 947.56 ns 947.56 ns
Mutex (Issue #30)     435.85 ns/iter   2,294,381.9  (428.7 ns … 458.39 ns) 435.39 ns 457.76 ns 458.39 ns


file:///Users/alisue/ogh/jsr-core/asyncutil/semaphore_bench.ts
benchmark              time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------------- -----------------------------
Semaphore              78.77 µs/iter      12,695.7    (61.62 µs … 1.81 ms) 68.04 µs 607.38 µs 665.96 µs
Semaphore (1.0.2)     296.69 µs/iter       3,370.6    (260.5 µs … 2.24 ms) 279.54 µs 635.88 µs 687.54 µs
```

Thanks to @PandaWorker 🎉 