### PR TITLE
feat(Semaphore): add `waiterCount` to reveal the number of locked resources

### DIFF
--- a/_raw_semaphore.ts
+++ b/_raw_semaphore.ts
@@ -30,6 +30,13 @@ export class RawSemaphore {
   }
 
   /**
+   * Returns the number of waiters that are waiting for lock release.
+   */
+  get waiterCount(): number {
+    return this.#resolves.length;
+  }
+
+  /**
    * Acquires the semaphore, blocking until the semaphore is available.
    */
   acquire(): Promise<void> {

--- a/deno.lock
+++ b/deno.lock
@@ -83,9 +83,12 @@
     "packageJson": {
       "dependencies": [
         "npm:@jsr/core__iterutil@^0.6.0-pre.0",
+        "npm:@jsr/core__unknownutil@^4.2.0",
         "npm:@jsr/cross__test",
         "npm:@jsr/std__assert",
-        "npm:@jsr/std__async@^1.0.3"
+        "npm:@jsr/std__async@^1.0.3",
+        "npm:@jsr/std__jsonc@^1.0.0-rc.3",
+        "npm:@jsr/std__path@^1.0.2"
       ]
     }
   }

--- a/semaphore.ts
+++ b/semaphore.ts
@@ -36,6 +36,13 @@ export class Semaphore {
   }
 
   /**
+   * Returns the number of waiters that are waiting for lock release.
+   */
+  get waiterCount(): number {
+    return this.#sem.waiterCount;
+  }
+
+  /**
    * Acquires a lock on the semaphore, and invokes the specified function.
    *
    * @param fn The function to invoke.


### PR DESCRIPTION
Close #43 

The name suggested was `lockedSize` but while `Notify` has `waiterCount` attribute that is quite similar to this, I added `waiterCount` attribute instead.